### PR TITLE
Fix BigDecimal deprecation warning

### DIFF
--- a/lib/money/distributed/fetcher/file.rb
+++ b/lib/money/distributed/fetcher/file.rb
@@ -19,7 +19,7 @@ class Money
         def exchange_rates
           open(@file_path).read.split("\n").each_with_object({}) do |line, h|
             code_rate = line.split(' ')
-            h[code_rate[0]] = BigDecimal.new(code_rate[1])
+            h[code_rate[0]] = BigDecimal(code_rate[1])
           end
         end
       end

--- a/lib/money/distributed/storage.rb
+++ b/lib/money/distributed/storage.rb
@@ -77,7 +77,7 @@ class Money
       def retrieve_rates
         @redis.exec do |r|
           r.hgetall(REDIS_KEY).each_with_object(@cache) do |(key, val), h|
-            h[key] = BigDecimal.new(val)
+            h[key] = BigDecimal(val)
           end
         end
         @cache_updated_at = Time.now


### PR DESCRIPTION
Fixes `warning: BigDecimal.new is deprecated; use BigDecimal() method instead.`