### PR TITLE
Shift Ruby support, Rubocop cleanup, Fix broken Storage#each_rate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.4
   - 2.5
   - 2.6
+  - 2.7
 services:
   - redis-server
 before_install: gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in money-distributed.gemspec

--- a/lib/money-distributed.rb
+++ b/lib/money-distributed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/distributed/storage'
 require 'money/distributed/fetcher/base'
 require 'money/distributed/fetcher/file'

--- a/lib/money/distributed/fetcher/base.rb
+++ b/lib/money/distributed/fetcher/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money'
 
 class Money
@@ -26,6 +28,7 @@ class Money
         def add_rate(from_iso, to_iso, rate)
           @bank.add_rate(from_iso, to_iso, rate.round(4))
           return if from_iso == to_iso
+
           @bank.add_rate(to_iso, from_iso, (1 / rate).round(4))
         end
 

--- a/lib/money/distributed/fetcher/base.rb
+++ b/lib/money/distributed/fetcher/base.rb
@@ -5,7 +5,7 @@ require 'money'
 class Money
   module Distributed
     module Fetcher
-      # Base class for reates fetchers
+      # Base class for rates fetchers
       module Base
         def initialize(bank = nil)
           @bank = bank || Money.default_bank

--- a/lib/money/distributed/fetcher/file.rb
+++ b/lib/money/distributed/fetcher/file.rb
@@ -19,7 +19,7 @@ class Money
         private
 
         def exchange_rates
-          open(@file_path).read.split("\n").each_with_object({}) do |line, h|
+          File.open(@file_path).read.split("\n").each_with_object({}) do |line, h|
             code_rate = line.split(' ')
             h[code_rate[0]] = BigDecimal(code_rate[1])
           end

--- a/lib/money/distributed/fetcher/file.rb
+++ b/lib/money/distributed/fetcher/file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'open-uri'
 require 'money/distributed/fetcher/base'

--- a/lib/money/distributed/fetcher/file.rb
+++ b/lib/money/distributed/fetcher/file.rb
@@ -19,7 +19,7 @@ class Money
         private
 
         def exchange_rates
-          File.open(@file_path).read.split("\n").each_with_object({}) do |line, h|
+          ::File.open(@file_path).read.split("\n").each_with_object({}) do |line, h|
             code_rate = line.split(' ')
             h[code_rate[0]] = BigDecimal(code_rate[1])
           end

--- a/lib/money/distributed/redis.rb
+++ b/lib/money/distributed/redis.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'redis'
 require 'connection_pool'
 

--- a/lib/money/distributed/storage.rb
+++ b/lib/money/distributed/storage.rb
@@ -31,7 +31,7 @@ class Money
         cached_rates[key_for(iso_from, iso_to)]
       end
 
-      def each_rate
+      def each_rate(&block)
         enum = Enumerator.new do |yielder|
           cached_rates.each do |key, rate|
             iso_from, iso_to = key.split(INDEX_KEY_SEPARATOR)

--- a/lib/money/distributed/storage.rb
+++ b/lib/money/distributed/storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bigdecimal'
 require 'money/distributed/redis'
 
@@ -5,8 +7,8 @@ class Money
   module Distributed
     # Storage for `Money::Bank::VariableExchange` that stores rates in Redis
     class Storage
-      INDEX_KEY_SEPARATOR = '_TO_'.freeze
-      REDIS_KEY = 'money_rates'.freeze
+      INDEX_KEY_SEPARATOR = '_TO_'
+      REDIS_KEY = 'money_rates'
 
       def initialize(redis, cache_ttl = nil)
         @redis = Money::Distributed::Redis.new(redis)
@@ -64,6 +66,7 @@ class Money
 
       def cache_outdated?
         return false unless @cache_ttl
+
         @cache_updated_at.nil? ||
           @cache_updated_at < Time.now - @cache_ttl
       end

--- a/lib/money/distributed/version.rb
+++ b/lib/money/distributed/version.rb
@@ -2,6 +2,6 @@
 
 class Money
   module Distributed
-    VERSION = '0.0.2.3'
+    VERSION = '1.0.0'
   end
 end

--- a/lib/money/distributed/version.rb
+++ b/lib/money/distributed/version.rb
@@ -2,6 +2,6 @@
 
 class Money
   module Distributed
-    VERSION = '1.0.0'
+    VERSION = '0.0.3'
   end
 end

--- a/lib/money/distributed/version.rb
+++ b/lib/money/distributed/version.rb
@@ -2,6 +2,6 @@
 
 class Money
   module Distributed
-    VERSION = '0.0.2.2'
+    VERSION = '0.0.2.3'
   end
 end

--- a/lib/money/distributed/version.rb
+++ b/lib/money/distributed/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class Money
   module Distributed
-    VERSION = '0.0.2.2'.freeze
+    VERSION = '0.0.2.2'
   end
 end

--- a/money-distributed.gemspec
+++ b/money-distributed.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '>= 3.0.0'
-  spec.add_development_dependency 'rubocop', '~> 0.49.0'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'timecop'
 
   spec.add_dependency 'connection_pool'

--- a/money-distributed.gemspec
+++ b/money-distributed.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/DarthSim/money-distributed'
   spec.license       = 'MIT'
 
+  spec.required_ruby_version = '~> 2.5' # rubocop:disable Gemspec/RequiredRubyVersion
+
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end

--- a/money-distributed.gemspec
+++ b/money-distributed.gemspec
@@ -1,6 +1,6 @@
-# coding: utf-8
+# frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'money/distributed/version'
 
@@ -24,10 +24,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
-  spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'rubocop', '~> 0.49.0'
+  spec.add_development_dependency 'timecop'
 
+  spec.add_dependency 'connection_pool'
   spec.add_dependency 'money', '>= 6.6.0'
   spec.add_dependency 'redis'
-  spec.add_dependency 'connection_pool'
 end

--- a/spec/fetcher/file_spec.rb
+++ b/spec/fetcher/file_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Money::Distributed::Fetcher::File do
-  let(:file_path) { File.expand_path('../../fixtures/rates.txt', __FILE__) }
+  let(:file_path) { File.expand_path('../fixtures/rates.txt', __dir__) }
   let(:bank) { double(add_rate: true) }
 
   subject { described_class.new(file_path, bank) }

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Money::Distributed::Redis do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec'
 require 'timecop'
 require 'money-distributed'

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Money::Distributed::Storage do


### PR DESCRIPTION
-  ⚠️ drop support for Ruby 2.4
- 🎉 add support for Ruby 2.7 
- 🤖 Rubocop cleanup 
- 🧑‍💻  fix passing block to `Money::Distributed::Storage#each_rate`, which is broken with Ruby >= 2.7 (I got the error `undefined local variable or method 'block' for #<Money::Distributed::Storage:0x00007fa4e7f39420>`). Find the interface for these methods here: https://github.com/RubyMoney/money#currency-exchange
- 🔐 don't use `Kernel#open` for security reasons, use `::File.open` (If the comment is right, the intention is to read a File) 